### PR TITLE
Add handling for RGB8 images without an alpha channel.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -130,6 +130,7 @@ menu = A.subparser
 
 unwrapImage ∷ DynamicImage → Maybe (Image PixelRGBA8)
 unwrapImage (ImageRGBA8 img) = Just img
+unwrapImage (ImageRGB8 img)  = Just (T.addAlphaChannel img)
 unwrapImage _                = Nothing
 
 run ∷ CommandType → IO ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -144,7 +144,7 @@ menu = A.subparser
 
 unwrapImage ∷ DynamicImage → Maybe (Image PixelRGBA8)
 unwrapImage (ImageRGBA8 img) = Just img
-unwrapImage (ImageRGB8 img)  = Just (T.addAlphaChannel img)
+unwrapImage (ImageRGB8 img)  = Just $ T.addAlphaChannel img
 unwrapImage _                = Nothing
 
 run ∷ CommandType → IO ()
@@ -153,6 +153,7 @@ run (SingleT inFile outFile f) = do
   case imageLoad of
     Left  error → putStrLn error
     Right image → case image of
+      ImageRGB8 img → writePng outFile . f $ T.addAlphaChannel img
       ImageRGBA8 img → writePng outFile $ f img
       _              → putStrLn "Type not handled yet."
 run (MultiT imgPaths outFile f) = do
@@ -168,6 +169,7 @@ run (ArgT inFile n outFile f) = do
   case imageLoad of
     Left error  → putStrLn error
     Right image → case image of
+      ImageRGB8 img → writePng outFile $ f n $ T.addAlphaChannel img
       ImageRGBA8 img → writePng outFile $ f n img
       _              → putStrLn "Type not handled yet."
 

--- a/src/Pixs/Transformation.hs
+++ b/src/Pixs/Transformation.hs
@@ -8,6 +8,7 @@ module Pixs.Transformation ( blur
                            , changeRed
                            , changeGreen
                            , changeBlue
+                           , addAlphaChannel
                            , changeBrightness
                            , negateImage
                            , saturation
@@ -26,6 +27,7 @@ import Control.Arrow ((***))
 import Data.Word
 import Data.Maybe (catMaybes)
 import Codec.Picture( PixelRGBA8(..)
+                    , PixelRGB8(..)
                     , Image(..)
                     , Pixel
                     , pixelMap
@@ -100,6 +102,10 @@ scale ∷ Double → PixelRGBA8 → PixelRGBA8
 scale n (PixelRGBA8 r g b a) = PixelRGBA8 r' g' b' a
   where
     [r', g', b'] = map (round . limit . (* n) . fromIntegral) [r, g, b]
+
+addAlphaChannel ∷ Image PixelRGB8 → Image PixelRGBA8
+addAlphaChannel = pixelMap addAlphaChannel'
+    where addAlphaChannel' (PixelRGB8 r g b) = PixelRGBA8 r g b 0xFF
 
 changeBrightness ∷ Int → Image PixelRGBA8 → Image PixelRGBA8
 changeBrightness amount = pixelMap changeBrightness'


### PR DESCRIPTION
I placed a function in Transformations.hs which adds an alpha channel to RGB8 images (effectively converting them to RGBA8). This is called from unwrapImages in Main.hs.

As a side note, I'm not sure how open you are to outside pull requests, but if you don't accept this, it will have been worth it for my own edification.